### PR TITLE
Use jagged layout NT through the MaskDecoder

### DIFF
--- a/segment_anything_fast/modeling/common.py
+++ b/segment_anything_fast/modeling/common.py
@@ -36,8 +36,8 @@ class LayerNorm2d(nn.Module):
         self.eps = eps
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        u = x.mean(1, keepdim=True)
-        s = (x - u).pow(2).mean(1, keepdim=True)
+        u = x.mean(-3, keepdim=True)
+        s = (x - u).pow(2).mean(-3, keepdim=True)
         x = (x - u) / torch.sqrt(s + self.eps)
         x = self.weight[:, None, None] * x + self.bias[:, None, None]
         return x


### PR DESCRIPTION
Slightly tweaks the model code to support passing a jagged layout nested tensor all the way through the MaskDecoder. This primarily involves calling view ops in a way that is agnostic to the number of input batch dims.

Relies on https://github.com/pytorch/pytorch/pull/111253