### PR TITLE
Update flash_4.py

### DIFF
--- a/segment_anything_fast/flash_4.py
+++ b/segment_anything_fast/flash_4.py
@@ -154,7 +154,8 @@ def _autotune(configs, function):
             t0 = benchmark.Timer(
                 stmt="f(*args, **kwargs)", globals={"args": args, "kwargs": kwargs, "f": f}
             )
-        except:
+        except Exception as e:
+            print(f"Error occured: {e}")
             return None
         return t0.blocked_autorange().mean * 1e6
 


### PR DESCRIPTION
log exception error for clarity.
In my case I could find by printing exception error
1. out of resource: shared memory, Required: 102432, Hardware limit: 101376. Reducing block sizes or `num_stages` may help.
2. [Cannot find appropriate C compiler on this system](https://askubuntu.com/questions/1340391/cannot-find-appropriate-c-compiler-on-this-system) : which was fixed by installing gcc