### PR TITLE
Fix torch bloat16 -> numpy float32 conversion for compile max-autotune

### DIFF
--- a/segment_anything_fast/predictor.py
+++ b/segment_anything_fast/predictor.py
@@ -162,8 +162,8 @@ class SamPredictor:
         )
 
         masks_np = masks[0].detach().cpu().numpy()
-        iou_predictions_np = iou_predictions[0].detach().cpu().numpy()
-        low_res_masks_np = low_res_masks[0].detach().cpu().numpy()
+        iou_predictions_np = iou_predictions[0].detach().cpu().float().numpy()
+        low_res_masks_np = low_res_masks[0].detach().cpu().float().numpy()
         return masks_np, iou_predictions_np, low_res_masks_np
 
     @torch.no_grad()


### PR DESCRIPTION
Tested on A6000 ADA, Torch 2.2.0.dev20231026. When running with the compiled, mixed precision model, the iou_predictions are in `bfloat16` which are not automatically castable to a numpy array.

As a workaround, I propose to cast those tensors to float before passing them to numpy, so you can avoid the problem.

Please note that float32 is more compatible than half, due to its representation limits.

Regards.