### PR TITLE
Add unit test and fix for flash_4

### DIFF
--- a/test/test_flash_4.py
+++ b/test/test_flash_4.py
@@ -39,6 +39,5 @@ def test_op(batch, head, seq_len, hidden_dim, dtype):
     torch.testing.assert_close(ref_out, tri_out, rtol=1e-3, atol=1e-3)
 
 for batch, (head, seq_len), dtype in itertools.product([1, 8], [(16, 80), (12, 64)], [torch.float16, torch.bfloat16]):
-# for batch, (head, seq_len), dtype in itertools.product([1, 8], [(16, 80)], [torch.float16, torch.bfloat16]):
     print(f"batch: {batch} head: {head} seq_len: {seq_len} dtype: {dtype}")
     test_op(batch, head, 4096, seq_len, dtype)

--- a/test/test_flash_4.py
+++ b/test/test_flash_4.py
@@ -1,44 +1,44 @@
 import torch
+import itertools
 from segment_anything_fast.flash_4 import _attention_rel_h_rel_w
 
-def test_op(batch, head, seq_len, hidden_dim, dtype=torch.float16):
+def test_op(batch, head, seq_len, hidden_dim, dtype):
     import math
 
     sm_scale = 1.0 / math.sqrt(hidden_dim)
     device = "cuda"
     torch.manual_seed(20)
-    q_ = torch.empty(
+    q = torch.empty(
         (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
     ).normal_(mean=0.0, std=0.5)
-    k_ = torch.empty(
+    k = torch.empty(
         (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
     ).normal_(mean=0.0, std=0.5)
-    v_ = torch.empty(
+    v = torch.empty(
         (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
     ).normal_(mean=0.0, std=0.5)
     w = int((seq_len) ** 0.5)
     assert w * w == seq_len, "seq_len must be a perfect square"
 
-    rel_h_ = torch.empty(
+    rel_h = torch.empty(
         (batch, head, seq_len, w, 1), dtype=dtype, device=device
     ).normal_(mean=0, std=0.5)
-    rel_w_ = torch.empty(
+    rel_w = torch.empty(
         (batch, head, seq_len, 1, w), dtype=dtype, device=device
     ).normal_(mean=0, std=0.5)
 
     tri_out = _attention_rel_h_rel_w(q, k, v, rel_h, rel_w)
     # reference implementation
-    attn_bias = (rel_h_ + rel_w_).view(
-        q_.size(0), q_.size(1), rel_h_.size(2), rel_h_.size(3) * rel_w_.size(4)
+    attn_bias = (rel_h + rel_w).view(
+        q.size(0), q.size(1), rel_h.size(2), rel_h.size(3) * rel_w.size(4)
     )
     ref_out = torch.nn.functional.scaled_dot_product_attention(
-        q_, k_, v_, attn_mask=attn_bias
+        q, k, v, attn_mask=attn_bias
     )
 
-    # compare
-    print("max diff: ", (ref_out - tri_out).abs().max().item())
-    print(
-        torch.nn.functional.cosine_similarity(ref_out.ravel(), tri_out.ravel(), dim=-1)
-    )
+    torch.testing.assert_close(ref_out, tri_out, rtol=1e-3, atol=1e-3)
 
-test_op(1, 16, 4096, 80, dtype=torch.float16)
+for batch, (head, seq_len), dtype in itertools.product([1, 8], [(16, 80), (12, 64)], [torch.float16, torch.bfloat16]):
+# for batch, (head, seq_len), dtype in itertools.product([1, 8], [(16, 80)], [torch.float16, torch.bfloat16]):
+    print(f"batch: {batch} head: {head} seq_len: {seq_len} dtype: {dtype}")
+    test_op(batch, head, 4096, seq_len, dtype)

--- a/test/test_flash_4.py
+++ b/test/test_flash_4.py
@@ -1,0 +1,42 @@
+import torch
+from segment_anything_fast.flash_4 import _attention_rel_h_rel_w
+
+def test_op(batch, head, seq_len, hidden_dim, dtype=torch.float16):
+    import math
+
+    sm_scale = 1.0 / math.sqrt(hidden_dim)
+    device = "cuda"
+    torch.manual_seed(20)
+    q_ = torch.empty(
+        (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
+    ).normal_(mean=0.0, std=0.5)
+    k_ = torch.empty(
+        (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
+    ).normal_(mean=0.0, std=0.5)
+    v_ = torch.empty(
+        (batch, head, seq_len, hidden_dim), dtype=dtype, device=device
+    ).normal_(mean=0.0, std=0.5)
+    w = int((seq_len) ** 0.5)
+    assert w * w == seq_len, "seq_len must be a perfect square"
+
+    rel_h_ = torch.empty(
+        (batch, head, seq_len, w, 1), dtype=dtype, device=device
+    ).normal_(mean=0, std=0.5)
+    rel_w_ = torch.empty(
+        (batch, head, seq_len, 1, w), dtype=dtype, device=device
+    ).normal_(mean=0, std=0.5)
+
+    tri_out = _attention_rel_h_rel_w(q, k, v, rel_h, rel_w)
+    # reference implementation
+    attn_bias = (rel_h_ + rel_w_).view(
+        q_.size(0), q_.size(1), rel_h_.size(2), rel_h_.size(3) * rel_w_.size(4)
+    )
+    ref_out = torch.nn.functional.scaled_dot_product_attention(
+        q_, k_, v_, attn_mask=attn_bias
+    )
+
+    # compare
+    print("max diff: ", (ref_out - tri_out).abs().max().item())
+    print(
+        torch.nn.functional.cosine_similarity(ref_out.ravel(), tri_out.ravel(), dim=-1)
+    )

--- a/test/test_flash_4.py
+++ b/test/test_flash_4.py
@@ -40,3 +40,5 @@ def test_op(batch, head, seq_len, hidden_dim, dtype=torch.float16):
     print(
         torch.nn.functional.cosine_similarity(ref_out.ravel(), tri_out.ravel(), dim=-1)
     )
+
+test_op(1, 16, 4096, 80, dtype=torch.float16)


### PR DESCRIPTION
All credit to https://github.com/pytorch-labs/segment-anything-fast/pull/71 and @zhanglei1172

This also adds more test cases and adjusts for a recent change in Triton frontend.

It also adds a batch size 1 guard against for vit_b where this kernel still seems to be incorrect.