### PR TITLE
Update time to ms on CPU

### DIFF
--- a/experiments/eval_combo.py
+++ b/experiments/eval_combo.py
@@ -103,7 +103,7 @@ def build_results_batch_nested(predictor, batch, batch_size, pad_input_image_bat
             torch.cuda.synchronize()
             elapsed_time = start_event.elapsed_time(end_event)
         else:
-            elapsed_time = time.time() - t0
+            elapsed_time = (time.time() - t0) * 1000
     return sum(result_batch, []), orig_input_image_batch_size, elapsed_time
 
 def build_results_batch(predictor, batch, batch_size, pad_input_image_batch):
@@ -173,7 +173,7 @@ def build_results_batch(predictor, batch, batch_size, pad_input_image_batch):
             torch.cuda.synchronize()
             elapsed_time = start_event.elapsed_time(end_event)
         else:
-            elapsed_time = time.time() - t0
+            elapsed_time = (time.time() - t0) * 1000
     return result_batch, orig_input_image_batch_size, elapsed_time
 
 


### PR DESCRIPTION
This PR is to update the `elapsed_time` to `ms` on CPU, aligned with CUDA. `start_event.elapsed_time` in CUDA is represented by `ms`, while `time.time()` is represented by `s`.